### PR TITLE
More Descriptive File Open Failure Errors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
-          "revision": "96ce86ebf9198328795c4b9cb711489460be083c",
-          "version": "3.4.4"
+          "revision": "1794ff138bd669175a2528d27695028d7cb30471",
+          "version": "3.5.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/vapor/crypto.git",
         "state": {
           "branch": null,
-          "revision": "5605334590affd4785a5839806b4504407e054ac",
-          "version": "3.3.0"
+          "revision": "bce9ac891c9b33fc045deda713e0d976d13b749a",
+          "version": "3.3.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/vapor/database-kit.git",
         "state": {
           "branch": null,
-          "revision": "3a17dbbe9be5f8c37703e4b7982c1332ad6b00c4",
-          "version": "1.3.1"
+          "revision": "3557894af50914e134803a684b42a9ea6eefaea2",
+          "version": "1.3.2"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/vapor/http.git",
         "state": {
           "branch": null,
-          "revision": "6973bf50dab8dd00e4daf8cb82ca72b33f5db016",
-          "version": "3.1.6"
+          "revision": "b57005e0de30ba36372ac41bfce1ac12b2bc3272",
+          "version": "3.1.8"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/vapor/multipart.git",
         "state": {
           "branch": null,
-          "revision": "e57007c23a52b68e44ebdfc70cbe882a7c4f1ec3",
-          "version": "3.0.2"
+          "revision": "bd7736c5f28e48ed8b683dcc9df3dcd346064c2b",
+          "version": "3.0.3"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "a20e129c22ad00a51c902dca54a5456f90664780",
-          "version": "1.12.0"
+          "revision": "98434c1f1d687ff5a24d2cabfbd19b5c7d2d7a2f",
+          "version": "1.13.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "db16c3a90b101bb53b26a58867a344ad428072e0",
-          "version": "1.3.2"
+          "revision": "0f3999f3e3c359cc74480c292644c3419e44a12f",
+          "version": "1.4.0"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "157d3b15336caa882662cc75024dd04b2e225246",
-          "version": "3.1.0"
+          "revision": "07cea7418f7641979b871216a9d7fbdec20644a7",
+          "version": "3.1.2"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/vapor/websocket.git",
         "state": {
           "branch": null,
-          "revision": "eb4277f75f1d96a3d15c852cdd89af1799093dcd",
-          "version": "1.1.0"
+          "revision": "21eb4773e25a8ff96fe347a31fe106900a69fa6a",
+          "version": "1.1.1"
         }
       }
     ]

--- a/Sources/Storage/LocalStorage.swift
+++ b/Sources/Storage/LocalStorage.swift
@@ -118,7 +118,7 @@ public struct LocalStorage: Storage, ServiceType {
             // The `O_EXCL` flag makes sure the file doesn't already exist.
             // The `O_CREAT` flag causes the file to be created since it doesn't exist.
             // The `O_TRUNC` flag removes any data from the file.
-            // The `O_RDWR` flag opens thje file to be either written or read.
+            // The `O_RDWR` flag opens the file to be either written or read.
             let fd = open(name, O_RDWR | O_TRUNC | O_CREAT | O_EXCL, S_IRWXU | S_IRGRP | S_IROTH)
             guard fd >= 0 else {
                 throw StorageError(identifier: "errno", reason: "(\(errno))" + String(cString: strerror(errno)))

--- a/Sources/Storage/LocalStorage.swift
+++ b/Sources/Storage/LocalStorage.swift
@@ -115,14 +115,12 @@ public struct LocalStorage: Storage, ServiceType {
                 throw StorageError(identifier: "pathRequired", reason: "A path is required to store files locally")
             }
             
-            // Create the path of the file to create, and make sure no file or directory already exists.
+            // Create the path of the file to create
             let name = path.last == "/" ? path + file.filename : path + "/" + file.filename
-            guard !self.manager.fileExists(atPath: name) else {
-                throw StorageError(identifier: "fileExists", reason: "A file already exists at path `\(name)`")
-            }
             
             // Create a new file and a `FileHandle` instance from its descriptor.
-            let fd = open(name, O_RDWR | O_TRUNC | O_CREAT, 0o644)
+            // The `O_EXCL` to make sure the file doesn't already exist.
+            let fd = open(name, O_RDWR | O_TRUNC | O_CREAT | O_EXCL, 0o644)
             guard fd >= 0 else {
                 throw StorageError(identifier: "fdErr", reason: "Received error code \(fd) when creating the new file")
             }

--- a/Sources/Storage/LocalStorage.swift
+++ b/Sources/Storage/LocalStorage.swift
@@ -124,7 +124,7 @@ public struct LocalStorage: Storage, ServiceType {
             guard fd >= 0 else {
                 throw StorageError(
                     identifier: "fdErr",
-                    reason: "Received error code \(fd) when creating the new file. Operation exited with \(errno)"
+                    reason: "Received error code \(fd) when creating the new file. Reveived errno \(errno)"
                 )
             }
             let handle = FileHandle(descriptor: fd)

--- a/Sources/Storage/LocalStorage.swift
+++ b/Sources/Storage/LocalStorage.swift
@@ -102,7 +102,7 @@ public struct LocalStorage: Storage, ServiceType {
     }
     
     /// See `Storage.store(file:at:)`.
-    public func store(file: File, at optionalPath: String?) -> EventLoopFuture<String> {
+    public func store(file: File, at optionalPath: String? = nil) -> EventLoopFuture<String> {
         do {
             
             // Get the path that the file will be created at.
@@ -187,7 +187,7 @@ public struct LocalStorage: Storage, ServiceType {
     }
     
     /// See `Storage.write(file:data:options:)`.
-    public func write(file: String, with data: Data, options: Data.WritingOptions) -> EventLoopFuture<File> {
+    public func write(file: String, with data: Data, options: Data.WritingOptions = []) -> EventLoopFuture<File> {
         do {
             // Make sure a file exists at the given path.
             try self.assert(path: file)

--- a/Sources/Storage/LocalStorage.swift
+++ b/Sources/Storage/LocalStorage.swift
@@ -122,7 +122,10 @@ public struct LocalStorage: Storage, ServiceType {
             // The `O_EXCL` to make sure the file doesn't already exist.
             let fd = open(name, O_RDWR | O_TRUNC | O_CREAT | O_EXCL, 0o644)
             guard fd >= 0 else {
-                throw StorageError(identifier: "fdErr", reason: "Received error code \(fd) when creating the new file")
+                throw StorageError(
+                    identifier: "fdErr",
+                    reason: "Received error code \(fd) when creating the new file. Operation exited with \(errno)"
+                )
             }
             let handle = FileHandle(descriptor: fd)
             

--- a/Tests/StorageTests/StorageTests.swift
+++ b/Tests/StorageTests/StorageTests.swift
@@ -44,7 +44,19 @@ final class StorageTests: XCTestCase {
         
         XCTAssertEqual(path, self.path + "/" + file.filename)
         
-        try FileManager.default.removeItem(atPath: path)
+        try XCTAssertNoThrow(FileManager.default.removeItem(atPath: path))
+    }
+    
+    func testPathWithWhitespace()throws {
+        try FileManager.default.createDirectory(atPath: self.path + "/Test Files", withIntermediateDirectories: false, attributes: nil)
+        
+        let storage = try self.app.make(LocalStorage.self)
+        let file = File(data: self.data, filename: "test.md")
+        let path = try storage.store(file: file, at: self.path + "/Test Files").wait()
+        
+        XCTAssertEqual(path, self.path + "/Test Files/" + file.filename)
+        
+        try FileManager.default.removeItem(atPath: self.path + "/Test Files")
     }
     
     func testFetch()throws {
@@ -85,6 +97,7 @@ final class StorageTests: XCTestCase {
     
     static var allTests: [(String, (StorageTests) -> ()throws -> ())] = [
         ("testStore", testStore),
+        ("testPathWithWhitespace", testPathWithWhitespace),
         ("testFetch", testFetch),
         ("testWrite", testWrite),
         ("testDelete", testDelete)


### PR DESCRIPTION
When we call `open` in the `LocalStorage.store` method, we might get a failure, but we are only notified by the call returning `-1`. Instead of throwing an error with that ambiguous number, we read `errno` and use that code returned and its string value as the error reason.